### PR TITLE
Fixes / updates for Flow ingest POC

### DIFF
--- a/webrtc/sendrecv/gst/README.txt
+++ b/webrtc/sendrecv/gst/README.txt
@@ -1,0 +1,3 @@
+Build:
+
+ gcc webrtc-sendrecv.c $(pkg-config --cflags --libs gstreamer-webrtc-1.0 gstreamer-sdp-1.0 libsoup-2.4 json-glib-1.0) -o webrtc-sendrecv

--- a/webrtc/sendrecv/gst/webrtc-sendrecv.c
+++ b/webrtc/sendrecv/gst/webrtc-sendrecv.c
@@ -376,14 +376,14 @@ start_pipeline (void)
 {
   GstStateChangeReturn ret;
   GError *error = NULL;
-
+;
   pipe1 =
-      gst_parse_launch ("webrtcbin bundle-policy=max-bundle name=sendrecv "
-      STUN_SERVER
-      "autovideosrc device=/dev/video0 ! videoconvert ! queue ! vp8enc deadline=1 ! rtpvp8pay ! "
-      "queue ! " RTP_CAPS_VP8 "96 ! sendrecv. "
-      "audiotestsrc is-live=true wave=red-noise ! audioconvert ! audioresample ! queue ! opusenc ! rtpopuspay ! "
-      "queue ! " RTP_CAPS_OPUS "97 ! sendrecv. ", &error);
+      gst_parse_launch ("webrtcbin name=sendrecv bundle-policy=max-bundle "
+      "autovideosrc device=/dev/video0            ! videoconvert ! queue ! vp8enc deadline=1 ! rtpvp8pay !  queue ! application/x-rtp,media=video,encoding-name=VP8,payload=97 ! sendrecv."
+      "videotestsrc is-live=true pattern=ball     ! videoconvert ! queue ! vp8enc deadline=1 ! rtpvp8pay !  queue ! application/x-rtp,media=video,encoding-name=VP8,payload=97 ! sendrecv."
+      "videotestsrc is-live=true pattern=smpte    ! videoconvert ! queue ! vp8enc deadline=1 ! rtpvp8pay !  queue ! application/x-rtp,media=video,encoding-name=VP8,payload=97 ! sendrecv."
+      "videotestsrc is-live=true pattern=snow     ! videoconvert ! queue ! vp8enc deadline=1 ! rtpvp8pay !  queue ! application/x-rtp,media=video,encoding-name=VP8,payload=97 ! sendrecv."
+      "videotestsrc is-live=true pattern=gradient ! videoconvert ! queue ! vp8enc deadline=1 ! rtpvp8pay !  queue ! application/x-rtp,media=video,encoding-name=VP8,payload=97 ! sendrecv.", &error);
 
   if (error) {
     gst_printerr ("Failed to parse launch: %s\n", error->message);

--- a/webrtc/sendrecv/gst/webrtc-sendrecv.c
+++ b/webrtc/sendrecv/gst/webrtc-sendrecv.c
@@ -380,7 +380,7 @@ start_pipeline (void)
   pipe1 =
       gst_parse_launch ("webrtcbin bundle-policy=max-bundle name=sendrecv "
       STUN_SERVER
-      "videotestsrc is-live=true pattern=ball ! videoconvert ! queue ! vp8enc deadline=1 ! rtpvp8pay ! "
+      "autovideosrc device=/dev/video0 ! videoconvert ! queue ! vp8enc deadline=1 ! rtpvp8pay ! "
       "queue ! " RTP_CAPS_VP8 "96 ! sendrecv. "
       "audiotestsrc is-live=true wave=red-noise ! audioconvert ! audioresample ! queue ! opusenc ! rtpopuspay ! "
       "queue ! " RTP_CAPS_OPUS "97 ! sendrecv. ", &error);

--- a/webrtc/sendrecv/gst/webrtc_sendrecv.py
+++ b/webrtc/sendrecv/gst/webrtc_sendrecv.py
@@ -1,5 +1,7 @@
-
 '''
+  These are the official GStreamer binding for Pything
+  @source https://gitlab.freedesktop.org/gstreamer/gst-python
+
   1. Run HOST the UI
 
   cd ~/development/gst-examples/webrtc/sendrecv/js
@@ -10,6 +12,11 @@
   cd ~/development/gst-examples/webrtc/sendrecv/gst
   python3 webrtc_signalling.py
   python3 webrtc_sendrecv.py
+
+
+ Refereces:
+ * https://brettviren.github.io/pygst-tutorial-org/pygst-tutorial.html
+ * https://github.com/GStreamer/gst-python/tree/master/testsuite/old
 
 '''
 
@@ -29,167 +36,52 @@ gi.require_version('GstWebRTC', '1.0')
 from gi.repository import GstWebRTC
 gi.require_version('GstSdp', '1.0')
 from gi.repository import GstSdp
-
 from threading import Timer
+from websockets.version import version as wsv
 
-# STUN_SERVER = 'stun:stun.services.mozilla.com'
-# STUN_SERVER = 'stun://stun.services.mozilla.com'
-STUN_SERVER = 'stun://stun.l.google.com:19302'
+DEFAULT_WS_SERVER = 'wss://127.0.0.1:8443'
+DEFAULT_STUN_SERVER = 'stun://stun.l.google.com:19302' # or 'stun://stun.services.mozilla.com'
+
+
 
 # Here's is the full pipeline (with 5 sources to be BUNDLED into one stream)
+# PIPELINE_DESC = '''
 #   webrtcbin name=sendrecv bundle-policy=max-bundle stun-server=stun://stun.l.google.com:19302
 #     videotestsrc is-live=true pattern=snow     ! videoconvert ! queue ! vp8enc deadline=1 ! rtpvp8pay ! queue ! application/x-rtp,media=video,encoding-name=VP8,payload=97 ! sendrecv.
 #     videotestsrc is-live=true pattern=ball     ! videoconvert ! queue ! vp8enc deadline=1 ! rtpvp8pay ! queue ! application/x-rtp,media=video,encoding-name=VP8,payload=97 ! sendrecv.
 #     videotestsrc is-live=true pattern=smpte    ! videoconvert ! queue ! vp8enc deadline=1 ! rtpvp8pay ! queue ! application/x-rtp,media=video,encoding-name=VP8,payload=97 ! sendrecv.
 #     videotestsrc is-live=true pattern=gradient ! videoconvert ! queue ! vp8enc deadline=1 ! rtpvp8pay ! queue ! application/x-rtp,media=video,encoding-name=VP8,payload=97 ! sendrecv.
+# '''
 
-# Pipeline with fakesink that we'll extend dynamically
+# Initial pipeline with RTP stream and fakesink that we'll extend dynamically as peers connect in
 PIPELINE_DESC = '''
     autovideosrc device=/dev/video0 ! videoconvert ! vp8enc deadline=1 ! rtpvp8pay ! application/x-rtp,media=video,encoding-name=VP8,payload=97 ! tee name=teapod teapod. ! queue ! fakesink
 '''
 
-from websockets.version import version as wsv
 
-class WebRTCClient:
-    def __init__(self, id_, server):
-        self.id_ = id_
-        self.idx = 0
-        self.conn = None
-        self.pipe = None
-        self.rtp = None
-        self.server = server or 'wss://127.0.0.1:8443'
-
-        # TODO: Handle this to support multiple clients
-        self.peer_id = None
+# A bin typically starts with a source, elements (mux, demux, encode, decode) and ends with a sink
+class GStreamberWebRTCBin:
+    def __init__(self, pipeline, peer_id):
+        self.pipeline = pipeline
+        self.peer_id = peer_id
         self.webrtc = None
 
-    async def connect(self):
-        sslctx = ssl.create_default_context(purpose=ssl.Purpose.CLIENT_AUTH)
-        self.conn = await websockets.connect(self.server, ssl=sslctx)
-        await self.conn.send('HELLO_SERVER')
-
-    def msg_peer(self, msg):
-        data = 'MSG_PEER %s %s' % ( self.peer_id, msg )
-    
-        loop = asyncio.new_event_loop()
-        loop.run_until_complete(self.conn.send(data))
-        loop.close()
-
-    def on_negotiation_needed(self, element):
-        promise = Gst.Promise.new_with_change_func(self.on_offer_created, element, None)
-        element.emit('create-offer', None, promise)
-
-    def on_offer_created(self, promise, _, __):
-        promise.wait()
-        reply = promise.get_reply()
-        offer = reply.get_value('offer')
-        promise = Gst.Promise.new()
-        self.webrtc.emit('set-local-description', offer, promise)
-        promise.interrupt()
-        self.send_sdp_offer(offer)
-
-    def send_sdp_offer(self, offer):
-        text = offer.sdp.as_text()
-        print ('Sending offer:\n%s' % text)
-        msg = json.dumps({'sdp': {'type': 'offer', 'sdp': text}})
-        self.msg_peer(msg)
-
-    def send_ice_candidate_message(self, _, mlineindex, candidate):
-        icemsg = json.dumps({'ice': {'candidate': candidate, 'sdpMLineIndex': mlineindex}})
-        self.msg_peer(icemsg)
-
-    def start_pipeline(self):
-        self.pipe = Gst.parse_launch(PIPELINE_DESC)
-
-        # Wait then add some test sources
-        # async_test1 = Timer(5.0, self.add_test_src, ["snow"],{})
-        # async_test1.start()
-        # async_test2 = Timer(10.0, self.add_test_src, ["ball"],{})
-        # async_test2.start()
-        # async_test3 = Timer(15.0, self.add_test_src, ["smpte"],{})
-        # async_test3.start()
-
-    def add_test_src(self, pattern):
-        self.idx = self.idx + 1
-        print ("Adding test source (%s) for pod nr %s" % (pattern, self.idx))
-
-        # Take source
-        test_src = Gst.ElementFactory.make("videotestsrc",      "test_src_%s" % self.idx)
-        test_src.set_property("is-live", "true")
-        test_src.set_property("pattern", pattern)
-
-        # split frames
-        converter = Gst.ElementFactory.make("videoconvert",     "test_con_%s" % self.idx)
-
-        # encode
-        encoder = Gst.ElementFactory.make("vp8enc",             "test_enc_%s" % self.idx)
-        encoder.set_property("deadline", 1)
-
-        # wrap (puts VP8 video in RTP packets)
-        rtp = Gst.ElementFactory.make("rtpvp8pay",              "test_rtp_%s" % self.idx)
-
-        # Set caps (capabilities - lightweight refcounted objects describing media types)
-        cap = "application/x-rtp,media=video,encoding-name=VP8,payload=97"
-        caps = Gst.caps_from_string(cap)
-        caps_filter = Gst.ElementFactory.make("capsfilter",     "test_cap_%s" % self.idx)
-        caps_filter.set_property("caps", caps)
-
-        # add to pipeline and link
-        self.pipe.add(test_src)
-        self.pipe.add(converter)
-        self.pipe.add(encoder)
-        self.pipe.add(rtp)
-        self.pipe.add(caps_filter)
-
-        test_src.link(converter)
-        converter.link(encoder)
-        encoder.link(rtp)
-        rtp.link(caps_filter)
-        caps_filter.link(self.rtp)
-
-        self.restart_stream()
-
-    def restart_stream(self):
-        if self.pipe.set_state == Gst.State.PLAYING:
-            self.pipe.set_state(Gst.State.PAUSED)
-            self.pipe.set_state(Gst.State.PLAYING)
-        else:
-            self.pipe.set_state(Gst.State.PLAYING)
-
-    def add_webrtc_peer(self, peer_id):
-        if self.peer_id == peer_id:
-            return print ("WARN: Peer already registered: %s" % peer_id) 
-
-        self.peer_id = peer_id
-
-        # Connect webrtcbin to running pipeline. There's the template that we'd normally use:
+        # Create webrtc bin (here's a template that we'd normally use):
         # queue ! webrtcbin name=sendrecv bundle-policy=max-bundle stun-server=stun://stun.l.google.com:19302
-
-        tee = self.pipe.get_by_name('teapod')
-
-        queue = Gst.ElementFactory.make('queue', 'queue_%s' % peer_id)
+        self.queue = Gst.ElementFactory.make('queue', 'queue_%s' % peer_id)
 
         self.webrtc = Gst.ElementFactory.make('webrtcbin', 'webrtc_bin_%s' % peer_id)
         self.webrtc.set_property('name', 'webrtc_bin_%s' % peer_id)
         self.webrtc.set_property('bundle-policy', 'max-bundle')
-        self.webrtc.set_property('stun-server', STUN_SERVER)
+        self.webrtc.set_property('stun-server', DEFAULT_STUN_SERVER)
         self.webrtc.connect('on-negotiation-needed', self.on_negotiation_needed)
         self.webrtc.connect('on-ice-candidate', self.send_ice_candidate_message)
 
-        self.pipe.add(queue)
-        self.pipe.add(self.webrtc)
+    def get_queue(self):
+        return self.queue
 
-        tee.link(queue)
-        queue.link(self.webrtc)
-
-        print("Starting stream for peer %s" % peer_id)
-        self.restart_stream()
-
-    def remove_webrtc_peer(self, peer_id):
-        if self.webrtc:
-            self.rtp.unlink(self.webrtc)
-            self.pipe.remove(self.webrtc)
-            self.restart_stream()
+    def get_sink(self):
+        return self.webrtc
 
     def handle_sdp(self, message):
         assert (self.webrtc)
@@ -212,11 +104,170 @@ class WebRTCClient:
             sdpmlineindex = ice['sdpMLineIndex']
             self.webrtc.emit('add-ice-candidate', sdpmlineindex, candidate)
 
+    def on_negotiation_needed(self, element):
+        promise = Gst.Promise.new_with_change_func(self.on_offer_created, element, None)
+        element.emit('create-offer', None, promise)
+
+    def on_offer_created(self, promise, _, __):
+        promise.wait()
+        reply = promise.get_reply()
+        offer = reply.get_value('offer')
+        promise = Gst.Promise.new()
+        self.webrtc.emit('set-local-description', offer, promise)
+        promise.interrupt()
+        self.send_sdp_offer(offer)
+
+    def send_sdp_offer(self, offer):
+        text = offer.sdp.as_text()
+        print ('Sending offer:\n%s' % text)
+        sdp_msg = json.dumps({'sdp': {'type': 'offer', 'sdp': text}})
+        self.pipeline.msg_peer(self.peer_id, sdp_msg)
+
+    def send_ice_candidate_message(self, _, mlineindex, candidate):
+        ice_msg = json.dumps({'ice': {'candidate': candidate, 'sdpMLineIndex': mlineindex}})
+        self.pipeline.msg_peer(self.peer_id, ice_msg)
+
+
+# Pipeline consists of GST bins and is the top-level structure
+class GStreamerWebRTCPipeline:
+    def __init__(self, server):
+        self.server = server or DEFAULT_WS_SERVER
+
+        self.bins = dict()
+        self.src_idx = 0
+
+        # Initially our pipline will stream to fakesink until browser connects 
+        self.start_pipeline()
+
+    # Connect to signaling server
+    async def connect(self):
+        sslctx = ssl.create_default_context(purpose=ssl.Purpose.CLIENT_AUTH)
+        self.conn = await websockets.connect(self.server, ssl=sslctx)
+        await self.conn.send('HELLO_SERVER')
+
+    # Send signal to WebRTC peer (eg. the browser)
+    def msg_peer(self, peer_id, msg):
+        data = 'MSG_PEER %s %s' % ( peer_id, msg )
+
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(self.conn.send(data))
+        loop.close()
+
+    def start_pipeline(self):
+        print("Starting pipeline")
+        self.pipe = Gst.parse_launch(PIPELINE_DESC)
+
+        # Wait then add some test sources
+        # async_test1 = Timer(5.0, self.add_test_src, ["snow"],{})
+        # async_test1.start()
+        # async_test2 = Timer(10.0, self.add_test_src, ["ball"],{})
+        # async_test2.start()
+        # async_test3 = Timer(15.0, self.add_test_src, ["smpte"],{})
+        # async_test3.start()
+
+    def add_test_src(self, pattern):
+        self.src_idx = self.src_idx + 1
+        print ("Adding test source (%s) for pod nr %s" % (pattern, self.src_idx))
+
+        # create test source
+        test_src = Gst.ElementFactory.make("videotestsrc",      "test_src_%s" % self.src_idx)
+        test_src.set_property("is-live", "true")
+        test_src.set_property("pattern", pattern)
+
+        # split frames
+        converter = Gst.ElementFactory.make("videoconvert",     "test_con_%s" % self.src_idx)
+
+        # encode
+        encoder = Gst.ElementFactory.make("vp8enc",             "test_enc_%s" % self.src_idx)
+        encoder.set_property("deadline", 1)
+
+        # wrap (puts VP8 video in RTP packets)
+        rtp = Gst.ElementFactory.make("rtpvp8pay",              "test_rtp_%s" % self.src_idx)
+
+        # Set caps (capabilities - lightweight refcounted objects describing media types)
+        cap = "application/x-rtp,media=video,encoding-name=VP8,payload=97"
+        caps = Gst.caps_from_string(cap)
+        caps_filter = Gst.ElementFactory.make("capsfilter",     "test_cap_%s" % self.src_idx)
+        caps_filter.set_property("caps", caps)
+
+        # add to pipeline and link
+        self.pipe.add(test_src)
+        self.pipe.add(converter)
+        self.pipe.add(encoder)
+        self.pipe.add(rtp)
+        self.pipe.add(caps_filter)
+
+        test_src.link(converter)
+        converter.link(encoder)
+        encoder.link(rtp)
+        rtp.link(caps_filter)
+        caps_filter.link(self.rtp)
+
+        self.restart_stream()
+
+    def restart_stream(self):
+        if self.pipe.get_state(1)[1] == Gst.State.PLAYING:
+            self.pipe.set_state(Gst.State.PAUSED)
+            self.pipe.set_state(Gst.State.PLAYING)
+        else:
+            self.pipe.set_state(Gst.State.PLAYING)
+
+    def add_webrtc_peer(self, peer_id):
+        if peer_id in self.bins:
+            return print ("WARN: Peer already registered: %s" % peer_id) 
+
+        # Create new GStreamer webrtc bin and link it to our pipeline
+        bin = self.bins[peer_id] = GStreamberWebRTCBin(self, peer_id)
+        queue = bin.get_queue()
+        sink = bin.get_sink()
+
+        self.pipe.add(queue)
+        self.pipe.add(sink)
+
+        tee = self.pipe.get_by_name('teapod')
+        tee.link(queue)
+        queue.link(sink)
+
+        print("Starting stream for peer %s" % peer_id)
+        self.restart_stream()
+
+
+    def msg_webrtc_peer(self, peer_id, msg):
+        if peer_id not in self.bins:
+            return print ("WARN: %s does not exist" % peer_id) 
+
+        bin = self.bins[peer_id]
+        bin.handle_sdp(msg)
+
+    #
+    # TODO: This maybe incomplete according to thi source
+    # https://gstreamer.freedesktop.org/documentation/application-development/advanced/pipeline-manipulation.html?gi-language=c#changing-elements-in-a-pipeline
+    #
+    def remove_webrtc_peer(self, peer_id):
+        if peer_id not in self.bins:
+            return print ("WARN: %s does not exist" % peer_id) 
+
+        print("Stopping stream for peer %s" % peer_id)
+
+        needsRestart = False
+        if self.pipe.get_state(1)[1] == Gst.State.PLAYING:
+            self.pipe.set_state(Gst.State.PAUSED)
+            needsRestart = True
+
+        queue = self.bins[peer_id].get_queue()
+        sink = self.bins[peer_id].get_sink()
+
+        queue.unlink(sink)
+        self.pipe.remove(queue)
+        self.pipe.remove(sink)
+        del self.bins[peer_id]
+
+        if needsRestart:
+            self.pipe.set_state(Gst.State.PLAYING)
+
     def close_pipeline(self):
         self.pipe.set_state(Gst.State.NULL)
-        self.pipe = None
-        self.rtp = None
-        self.webrtc = None
+        self.bins = dict()
 
     async def loop(self):
         assert self.conn
@@ -224,25 +275,29 @@ class WebRTCClient:
             print("signal: %s" % message); 
 
             if message.startswith('HELLO'):
-                # Initially our pipline will stream to fakesink until browser connects 
-                print("Starting pipeline")
-                self.start_pipeline()
-                print("Started. Awaiting peers...")
+                print("Received HELLO. Awaiting peers...")
 
             elif message.startswith('PEER_CONNECTED'):
                 _, peer_id = message.split(maxsplit=1)
                 self.add_webrtc_peer(peer_id)
+                print('New peer added. Total peers: %d' % len(self.bins))
+
+            elif message.startswith('PEER_MESSAGE'):
+                _, peer_id, msg = message.split(maxsplit=2)
+                self.msg_webrtc_peer(peer_id, msg)
 
             elif message.startswith('PEER_DISCONNECTED'):
                 _, peer_id = message.split(maxsplit=1)
                 self.remove_webrtc_peer(peer_id)
+                print('Peer removed. Total peers: %d' % len(self.bins))
 
             elif message.startswith('ERROR'):
                 self.close_pipeline()
                 return 1
 
             else:
-                self.handle_sdp(message)
+                print("WARN: signal was unhandled"); 
+
         self.close_pipeline()
         return 0
 
@@ -252,29 +307,37 @@ class WebRTCClient:
         self.conn = None
 
 
+# Check that our gstreamer setup is complete
 def check_plugins():
     needed = ["opus", "vpx", "nice", "webrtc", "dtls", "srtp", "rtp",
               "rtpmanager", "videotestsrc", "audiotestsrc"]
     missing = list(filter(lambda p: Gst.Registry.get().find_plugin(p) is None, needed))
     if len(missing):
-        print('Missing gstreamer plugins:', missing)
+        print('ERROR: Missing gstreamer plugins:', missing)
         return False
     return True
 
+def check_versions():
+    if Gst.VERSION_MAJOR < 1 or Gst.VERSION_MINOR < 14:
+        print('ERROR: Please use GStreamer version 1.14 (ideally 1.18)')
+        return False
+    return True
 
 if __name__=='__main__':
     Gst.init(None)
     if not check_plugins():
         sys.exit(1)
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--server', help='Signalling server to connect to, eg "wss://127.0.0.1:8443"')
-    args = parser.parse_args()
-    our_id = random.randrange(10, 10000)
+    if not check_versions():
+        sys.exit(2)
 
-    c = WebRTCClient(our_id, args.server)
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--server', help='Signalling server to connect to (defaults to "%s")' % DEFAULT_WS_SERVER)
+    args = parser.parse_args()
+
+    pipeline = GStreamerWebRTCPipeline(args.server)
     loop = asyncio.get_event_loop()
-    loop.run_until_complete(c.connect())
-    res = loop.run_until_complete(c.loop())
+    loop.run_until_complete(pipeline.connect())
+    res = loop.run_until_complete(pipeline.loop())
     sys.exit(res)
 
 

--- a/webrtc/sendrecv/gst/webrtc_sendrecv.py
+++ b/webrtc/sendrecv/gst/webrtc_sendrecv.py
@@ -24,10 +24,14 @@ from gi.repository import GstSdp
 
 PIPELINE_DESC = '''
 webrtcbin name=sendrecv bundle-policy=max-bundle
- autovideosrc device=/dev/video0 ! videoconvert ! queue ! vp8enc deadline=1 ! rtpvp8pay !
- queue ! application/x-rtp,media=video,encoding-name=VP8,payload=97 ! sendrecv.
+ autovideosrc device=/dev/video0            ! videoconvert ! queue ! vp8enc deadline=1 ! rtpvp8pay !  queue ! application/x-rtp,media=video,encoding-name=VP8,payload=97 ! sendrecv.
+ videotestsrc is-live=true pattern=snow     ! videoconvert ! queue ! vp8enc deadline=1 ! rtpvp8pay !  queue ! application/x-rtp,media=video,encoding-name=VP8,payload=97 ! sendrecv.
+ videotestsrc is-live=true pattern=ball     ! videoconvert ! queue ! vp8enc deadline=1 ! rtpvp8pay !  queue ! application/x-rtp,media=video,encoding-name=VP8,payload=97 ! sendrecv.
+ videotestsrc is-live=true pattern=smpte    ! videoconvert ! queue ! vp8enc deadline=1 ! rtpvp8pay !  queue ! application/x-rtp,media=video,encoding-name=VP8,payload=97 ! sendrecv.
+ videotestsrc is-live=true pattern=gradient ! videoconvert ! queue ! vp8enc deadline=1 ! rtpvp8pay !  queue ! application/x-rtp,media=video,encoding-name=VP8,payload=97 ! sendrecv.
 '''
 
+## TODO: Create 16 low-quality channels
 
 from websockets.version import version as wsv
 

--- a/webrtc/sendrecv/gst/webrtc_sendrecv.py
+++ b/webrtc/sendrecv/gst/webrtc_sendrecv.py
@@ -15,12 +15,17 @@ from gi.repository import GstWebRTC
 gi.require_version('GstSdp', '1.0')
 from gi.repository import GstSdp
 
+# PIPELINE_DESC = '''
+# webrtcbin name=sendrecv bundle-policy=max-bundle stun-server=stun://stun.l.google.com:19302
+# autovideosrc device=/dev/video0 ! videoconvert ! queue !
+# x264enc ! video/x-h264, profile=baseline ! rtph264pay !
+# queue ! application/x-rtp,media=video,encoding-name=H264,payload=96  ! sendrecv.
+# '''
+
 PIPELINE_DESC = '''
-webrtcbin name=sendrecv bundle-policy=max-bundle stun-server=stun://stun.l.google.com:19302
- videotestsrc is-live=true pattern=ball ! videoconvert ! queue ! vp8enc deadline=1 ! rtpvp8pay !
+webrtcbin name=sendrecv bundle-policy=max-bundle
+ autovideosrc device=/dev/video0 ! videoconvert ! queue ! vp8enc deadline=1 ! rtpvp8pay !
  queue ! application/x-rtp,media=video,encoding-name=VP8,payload=97 ! sendrecv.
- audiotestsrc is-live=true wave=red-noise ! audioconvert ! audioresample ! queue ! opusenc ! rtpopuspay !
- queue ! application/x-rtp,media=audio,encoding-name=OPUS,payload=96 ! sendrecv.
 '''
 
 
@@ -136,6 +141,7 @@ class WebRTCClient:
         elif 'ice' in msg:
             ice = msg['ice']
             candidate = ice['candidate']
+            print ('Received candidate: ', candidate)
             sdpmlineindex = ice['sdpMLineIndex']
             self.webrtc.emit('add-ice-candidate', sdpmlineindex, candidate)
 

--- a/webrtc/sendrecv/gst/webrtc_sendrecv.py
+++ b/webrtc/sendrecv/gst/webrtc_sendrecv.py
@@ -23,6 +23,7 @@ webrtcbin name=sendrecv bundle-policy=max-bundle stun-server=stun://stun.l.googl
  queue ! application/x-rtp,media=audio,encoding-name=OPUS,payload=96 ! sendrecv.
 '''
 
+
 from websockets.version import version as wsv
 
 class WebRTCClient:
@@ -54,7 +55,7 @@ class WebRTCClient:
     def on_offer_created(self, promise, _, __):
         promise.wait()
         reply = promise.get_reply()
-        offer = reply['offer']
+        offer = reply.get_value('offer')
         promise = Gst.Promise.new()
         self.webrtc.emit('set-local-description', offer, promise)
         promise.interrupt()

--- a/webrtc/sendrecv/gst/webrtc_signalling.py
+++ b/webrtc/sendrecv/gst/webrtc_signalling.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import ssl
+import logging
+import asyncio
+import websockets
+import argparse
+import http
+import concurrent
+
+class WebRTCSignalingServer(object):
+
+    def __init__(self, loop, options):
+        ############### Global data ###############
+
+        # Event loop
+        self.loop = loop
+
+        # Websocket Server Instance
+        self.server = None
+
+        # Peers: Browsers
+        self.peers = dict()
+
+        # Peer: Gstreamer
+        self.gstreamer = None
+
+        # Options
+        self.addr = options.addr
+        self.port = options.port
+        self.keepalive_timeout = options.keepalive_timeout
+        self.cert_restart = options.cert_restart
+        self.cert_path = options.cert_path
+        self.disable_ssl = options.disable_ssl
+        self.health_path = options.health
+
+        # Certificate mtime, used to detect when to restart the server
+        self.cert_mtime = -1
+
+    ############### Helper functions ###############
+
+    async def health_check(self, path, request_headers):
+        if path == self.health_path:
+            return http.HTTPStatus.OK, [], b"OK\n"
+        return None
+
+    async def recv_msg_ping(self, ws, raddr):
+        '''
+        Wait for a message forever, and send a regular ping to prevent bad routers
+        from closing the connection.
+        '''
+        msg = None
+        while msg is None:
+            try:
+                msg = await asyncio.wait_for(ws.recv(), self.keepalive_timeout)
+            except (asyncio.TimeoutError, concurrent.futures._base.TimeoutError):
+                # print('Sending keepalive ping to {!r} in recv'.format(raddr))
+                await ws.ping()
+        return msg
+
+    ############### Handler functions ###############
+
+    
+    async def connection_handler(self, ws):
+        while True:
+            # Receive command, wait forever if necessary
+            msg = await self.recv_msg_ping(ws, ws.remote_address)
+
+            print(msg)
+
+            # GStreamer server connected: 
+            # HELLO_SERVER
+            if msg.startswith('HELLO_SERVER'):
+                print ('GStreamer connected')
+                self.gstreamer = ws
+                await self.gstreamer.send('HELLO')
+
+                # Let peers know
+                for peer_id in self.peers:
+                    await self.peers[peer_id].send('SERVER_CONNECTED')
+
+
+            # Browser connected
+            # HELLO_PEER 1234
+            elif msg.startswith('HELLO_PEER'):
+                _, peer_id = msg.split(maxsplit=1)
+                self.peers[peer_id] = ws
+                await self.peers[peer_id].send('HELLO')
+
+                # Let server know
+                if self.gstreamer:
+                    await self.gstreamer.send('PEER_CONNECTED %s' % peer_id)
+
+            # Browser wants to message server
+            # MSG_SERVER {"sdp": {...}}
+            elif msg.startswith('MSG_SERVER'):
+                _, json = msg.split(maxsplit=1)
+                if self.gstreamer:
+                    await self.gstreamer.send(json)
+                else:
+                    print('WARN: Server not set yet')
+
+            # Server wants to meesage prowser
+            # MSG_PEER 1234 {"sdp": {...}}
+            elif msg.startswith('MSG_PEER'):
+                _, peer_id, json = msg.split(maxsplit=2)
+                if self.peers[peer_id]:
+                    await self.peers[peer_id].send(json)
+                else:
+                    print('WARN: Peer %s does not exist' % peer_id)
+
+    def get_ssl_certs(self):
+        chain_pem = '/etc/editshare/ssl/server-cert.pem'
+        key_pem = '/etc/editshare/ssl/server.key'
+        return chain_pem, key_pem
+
+    def get_ssl_ctx(self):
+        if self.disable_ssl:
+            return None
+        # Create an SSL context to be used by the websocket server
+        print('Using TLS with keys in {!r}'.format(self.cert_path))
+        chain_pem, key_pem = self.get_ssl_certs()
+        sslctx = ssl.create_default_context()
+        try:
+            sslctx.load_cert_chain(chain_pem, keyfile=key_pem)
+        except FileNotFoundError:
+            print("Certificates not found, did you run generate_cert.sh?")
+            sys.exit(1)
+        # FIXME
+        sslctx.check_hostname = False
+        sslctx.verify_mode = ssl.CERT_NONE
+        return sslctx
+
+    def run(self):
+        async def handler(ws, path):
+            '''
+            All incoming messages are handled here. @path is unused.
+            '''
+            raddr = ws.remote_address
+            print("Connected to {!r}".format(raddr))
+
+            try:
+                await self.connection_handler(ws)
+            except websockets.ConnectionClosed:
+                print("Connection to peer {!r} closed, exiting handler".format(raddr))
+            finally:
+                if self.gstreamer == ws:
+                    self.gstreamer = None
+                else:
+                    for peer_id in self.peers:
+                        if self.peers[peer_id] == ws:
+                            del self.peers[peer_id]
+
+
+        sslctx = self.get_ssl_ctx()
+
+        print("Listening on https://{}:{}".format(self.addr, self.port))
+        # Websocket server
+        wsd = websockets.serve(handler, self.addr, self.port, ssl=sslctx, process_request=self.health_check if self.health_path else None,
+                               # Maximum number of messages that websockets will pop
+                               # off the asyncio and OS buffers per connection. See:
+                               # https://websockets.readthedocs.io/en/stable/api.html#websockets.protocol.WebSocketCommonProtocol
+                               max_queue=16)
+
+        # Setup logging
+        logger = logging.getLogger('websockets')
+        logger.setLevel(logging.INFO)
+        logger.addHandler(logging.StreamHandler())
+
+        # Run the server
+        self.server = self.loop.run_until_complete(wsd)
+        # Stop the server if certificate changes
+        self.loop.run_until_complete(self.check_server_needs_restart())
+
+    async def stop(self):
+        print('Stopping server... ', end='')
+        self.server.close()
+        await self.server.wait_closed()
+        self.loop.stop()
+        print('Stopped.')
+
+    def check_cert_changed(self):
+        chain_pem, key_pem = self.get_ssl_certs()
+        mtime = max(os.stat(key_pem).st_mtime, os.stat(chain_pem).st_mtime)
+        if self.cert_mtime < 0:
+            self.cert_mtime = mtime
+            return False
+        if mtime > self.cert_mtime:
+            self.cert_mtime = mtime
+            return True
+        return False
+
+    async def check_server_needs_restart(self):
+        "When the certificate changes, we need to restart the server"
+        if not self.cert_restart:
+            return
+        while True:
+            await asyncio.sleep(10)
+            if self.check_cert_changed():
+                print('Certificate changed, stopping server...')
+                await self.stop()
+                return
+
+
+def main():
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    # See: host, port in https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.create_server
+    parser.add_argument('--addr', default='', help='Address to listen on (default: all interfaces, both ipv4 and ipv6)')
+    parser.add_argument('--port', default=8443, type=int, help='Port to listen on')
+    parser.add_argument('--keepalive-timeout', dest='keepalive_timeout', default=30, type=int, help='Timeout for keepalive (in seconds)')
+    parser.add_argument('--cert-path', default=os.path.dirname(__file__))
+    parser.add_argument('--disable-ssl', default=False, help='Disable ssl', action='store_true')
+    parser.add_argument('--health', default='/health', help='Health check route')
+    parser.add_argument('--restart-on-cert-change', default=False, dest='cert_restart', action='store_true', help='Automatically restart if the SSL certificate changes')
+
+    options = parser.parse_args(sys.argv[1:])
+
+    loop = asyncio.get_event_loop()
+
+    r = WebRTCSignalingServer(loop, options)
+
+    print('Starting server...')
+    while True:
+        r.run()
+        loop.run_forever()
+        print('Restarting server...')
+    print("Goodbye!")
+
+if __name__ == "__main__":
+    main()

--- a/webrtc/sendrecv/js/index.html
+++ b/webrtc/sendrecv/js/index.html
@@ -37,6 +37,8 @@
     <div>Status: <span id="status">unknown</span></div>
     <div><textarea id="text" cols=40 rows=4></textarea></div>
     <div>Our id is <b id="peer-id">unknown</b></div>
+    <button type="submit" onclick="initializeWebRTC()">Connect to server now</button>
+    <br/>
     <br/>
 
     NOTE: If you see red error go

--- a/webrtc/sendrecv/js/index.html
+++ b/webrtc/sendrecv/js/index.html
@@ -22,6 +22,9 @@
     <script src="webrtc.js"></script>
     <script>
       window.onload = websocketServerConnect;
+
+      // Won't work in Chrome
+      // setTimeout(() => initializeWebRTC(), 1000);
     </script>
   </head>
 
@@ -35,8 +38,13 @@
     <br>
 
     <div>Status: <span id="status">unknown</span></div>
-    <div><textarea id="text" cols=40 rows=4></textarea></div>
+
+    <div style="display: none;"><textarea id="text" cols=40 rows=4></textarea></div>
+
     <div>Our id is <b id="peer-id">unknown</b></div>
+
+    <br>
+    
     <button type="submit" onclick="initializeWebRTC()">Connect to server now</button>
     <br/>
     <br/>

--- a/webrtc/sendrecv/js/index.html
+++ b/webrtc/sendrecv/js/index.html
@@ -16,7 +16,7 @@
       .error { color: red; }
       video { height: 200px }
       table { width: 100%; border: 1px solid grey; text-align: center }
-      .table-cell { border: 1px solid gray; background: gray }
+      table td { border: 1px solid gray; background: gray }
     </style>
     <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
     <script src="webrtc.js"></script>
@@ -27,23 +27,8 @@
 
   <body>
     <table>
-      <thead>
-        <tr>
-          <td>Stream 0 / CAM1</td>
-          <td>Stream 1 / Test 1</td>
-          <td>Stream 2 / Test 2</td>
-          <td>Stream 3 / Test 3</td>
-          <td>Stream 4 / Test 4</td>
-        </tr>
-      </thead>
       <tbody>
-        <tr>
-          <td class="table-cell"><video id="stream0" autoplay playsinline></video></td>
-          <td class="table-cell"><video id="stream1" autoplay playsinline></video></td>
-          <td class="table-cell"><video id="stream2" autoplay playsinline></video></td>
-          <td class="table-cell"><video id="stream3" autoplay playsinline></video></td>
-          <td class="table-cell"><video id="stream4" autoplay playsinline></video></td>
-        </tr>
+        <tr id="streams"></tr>
       </tbody>
     </table>
 

--- a/webrtc/sendrecv/js/index.html
+++ b/webrtc/sendrecv/js/index.html
@@ -14,6 +14,9 @@
     <meta charset="utf-8"/>
     <style>
       .error { color: red; }
+      video { height: 200px }
+      table { width: 100%; border: 1px solid grey; text-align: center }
+      .table-cell { border: 1px solid gray; background: gray }
     </style>
     <script src="https://webrtc.github.io/adapter/adapter-latest.js"></script>
     <script src="webrtc.js"></script>
@@ -23,10 +26,40 @@
   </head>
 
   <body>
-    <div><video id="stream" autoplay playsinline>Your browser doesn't support video</video></div>
+    <table>
+      <thead>
+        <tr>
+          <td>Stream 0 / CAM1</td>
+          <td>Stream 1 / Test 1</td>
+          <td>Stream 2 / Test 2</td>
+          <td>Stream 3 / Test 3</td>
+          <td>Stream 4 / Test 4</td>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="table-cell"><video id="stream0" autoplay playsinline></video></td>
+          <td class="table-cell"><video id="stream1" autoplay playsinline></video></td>
+          <td class="table-cell"><video id="stream2" autoplay playsinline></video></td>
+          <td class="table-cell"><video id="stream3" autoplay playsinline></video></td>
+          <td class="table-cell"><video id="stream4" autoplay playsinline></video></td>
+        </tr>
+      </tbody>
+    </table>
+
+    <br>
+
     <div>Status: <span id="status">unknown</span></div>
     <div><textarea id="text" cols=40 rows=4></textarea></div>
     <div>Our id is <b id="peer-id">unknown</b></div>
     <br/>
+
+    NOTE: If you see red error go
+    <script>
+      var url = 'https://' + window.location.hostname + ':8443';
+      document.write('<a target="_blank" href="'+ url +'">here</a>');
+    </script>
+    and accept certificate warning
+
   </body>
 </html>

--- a/webrtc/sendrecv/js/index.html
+++ b/webrtc/sendrecv/js/index.html
@@ -28,9 +28,5 @@
     <div><textarea id="text" cols=40 rows=4></textarea></div>
     <div>Our id is <b id="peer-id">unknown</b></div>
     <br/>
-    <div>
-      <div>getUserMedia constraints being used:</div>
-      <div><textarea id="constraints" cols=40 rows=4></textarea></div>
-    </div>
   </body>
 </html>

--- a/webrtc/sendrecv/js/webrtc.js
+++ b/webrtc/sendrecv/js/webrtc.js
@@ -228,8 +228,7 @@ function onRemoteTrack(event) {
     cell.appendChild(video);
     row.appendChild(cell);
 
-    video.srcObject = event.streams[0];
-
+    video.srcObject = new MediaStream([event.track]);
 }
 
 const handleDataChannelOpen = (event) =>{

--- a/webrtc/sendrecv/js/webrtc.js
+++ b/webrtc/sendrecv/js/webrtc.js
@@ -29,6 +29,7 @@ var ws_conn;
 var peer_id;
 
 function getOurId() {
+    // TODO: We'd better off generating UUIDs
     return Math.floor(Math.random() * (900000 - 1000) + 1000).toString();
 }
 

--- a/webrtc/sendrecv/js/webrtc.js
+++ b/webrtc/sendrecv/js/webrtc.js
@@ -29,7 +29,7 @@ var ws_conn;
 var peer_id;
 
 function getOurId() {
-    return Math.floor(Math.random() * (9000 - 10) + 10).toString();
+    return Math.floor(Math.random() * (900000 - 1000) + 1000).toString();
 }
 
 function resetState() {
@@ -94,7 +94,7 @@ function onLocalDescription(desc) {
     peer_connection.setLocalDescription(desc).then(function() {
         const sdp = {'sdp': peer_connection.localDescription}
 
-        ws_conn.send('MSG_SERVER ' + JSON.stringify(sdp));
+        ws_conn.send('MSG_SERVER ' + peer_id + ' ' + JSON.stringify(sdp));
         setStatus("Sent SDP " + desc.type);
 
         // setStatus("Signaling server to start pipeline" + desc.type);
@@ -288,7 +288,8 @@ function createCall(msg) {
         }
 
         console.log("ICE Candidate added", event.candidate);
-        ws_conn.send('MSG_SERVER ' + JSON.stringify({'ice': event.candidate}));
+        ws_conn.send('MSG_SERVER ' + peer_id + ' ' + JSON.stringify({'ice': event.candidate}));
+        setStatus("Sent ICE candidates");
     };
 
     if (msg != null) setStatus("Created peer connection for call, waiting for SDP");

--- a/webrtc/sendrecv/js/webrtc.js
+++ b/webrtc/sendrecv/js/webrtc.js
@@ -13,17 +13,19 @@ var ws_port;
 // Set this to use a specific peer id instead of a random one
 var default_peer_id;
 // Override with your own STUN servers if you want
-var rtc_configuration = {iceServers: [{urls: "stun:stun.services.mozilla.com"},
-                                      {urls: "stun:stun.l.google.com:19302"}]};
-// The default constraints that will be attempted. Can be overriden by the user.
-var default_constraints = {video: true, audio: true};
+var rtc_configuration = {
+    iceServers: [
+        { urls: "stun:stun.services.mozilla.com" },
+        { urls: "stun:stun.l.google.com:19302" },
+        // { urls: `stun:${window.location.hostname}:3478` },
+        // { urls: `stun:${window.location.hostname}:3479` },
+    ]
+};
 
 var connect_attempts = 0;
 var peer_connection;
 var send_channel;
 var ws_conn;
-// Promise for local stream after constraints are approved by the user
-var local_stream_promise;
 
 function getOurId() {
     return Math.floor(Math.random() * (9000 - 10) + 10).toString();
@@ -59,14 +61,6 @@ function setError(text) {
 }
 
 function resetVideo() {
-    // Release the webcam and mic
-    if (local_stream_promise)
-        local_stream_promise.then(stream => {
-            if (stream) {
-                stream.getTracks().forEach(function (track) { track.stop(); });
-            }
-        });
-
     // Reset the video element and stop showing the last received frame
     var videoElement = getVideoElement();
     videoElement.pause();
@@ -78,14 +72,13 @@ function resetVideo() {
 function onIncomingSDP(sdp) {
     peer_connection.setRemoteDescription(sdp).then(() => {
         setStatus("Remote SDP set");
-        if (sdp.type != "offer")
+        if (sdp.type !== "offer")
             return;
         setStatus("Got SDP offer");
-        local_stream_promise.then((stream) => {
-            setStatus("Got local stream, creating answer");
-            peer_connection.createAnswer()
-            .then(onLocalDescription).catch(setError);
-        }).catch(setError);
+
+        peer_connection.createAnswer()
+            .then(onLocalDescription)
+            .catch(setError);
     }).catch(setError);
 }
 
@@ -94,8 +87,11 @@ function onLocalDescription(desc) {
     console.log("Got local description: " + JSON.stringify(desc));
     peer_connection.setLocalDescription(desc).then(function() {
         setStatus("Sending SDP " + desc.type);
-        sdp = {'sdp': peer_connection.localDescription}
+        const sdp = {'sdp': peer_connection.localDescription}
         ws_conn.send(JSON.stringify(sdp));
+
+        // setStatus("Signaling server to start pipeline" + desc.type);
+        // ws_conn.send('SESSION_OK');
     });
 }
 
@@ -111,45 +107,48 @@ function onIncomingICE(ice) {
 
 function onServerMessage(event) {
     console.log("Received " + event.data);
-    switch (event.data) {
-        case "HELLO":
-            setStatus("Registered with server, waiting for call");
-            return;
-        default:
-            if (event.data.startsWith("ERROR")) {
-                handleIncomingError(event.data);
-                return;
-            }
-	    if (event.data.startsWith("OFFER_REQUEST")) {
-	      // The peer wants us to set up and then send an offer
-              if (!peer_connection)
-                  createCall(null).then (generateOffer);
-	    }
-            else {
-                // Handle incoming JSON SDP and ICE messages
-                try {
-                    msg = JSON.parse(event.data);
-                } catch (e) {
-                    if (e instanceof SyntaxError) {
-                        handleIncomingError("Error parsing incoming JSON: " + event.data);
-                    } else {
-                        handleIncomingError("Unknown error parsing response: " + event.data);
-                    }
-                    return;
-                }
 
-                // Incoming JSON signals the beginning of a call
-                if (!peer_connection)
-                    createCall(msg);
+    if (event.data === "HELLO") {
+        return setStatus("Registered with server, waiting for call");
+    }
 
-                if (msg.sdp != null) {
-                    onIncomingSDP(msg.sdp);
-                } else if (msg.ice != null) {
-                    onIncomingICE(msg.ice);
-                } else {
-                    handleIncomingError("Unknown incoming JSON: " + msg);
-                }
-	    }
+    if (event.data.startsWith("ERROR")) {
+        return handleIncomingError(event.data);
+    }
+
+    // The peer wants us to set up and then send an offer
+    if (event.data.startsWith("OFFER_REQUEST")) {
+        // We should be ignore this for now
+        alert('OFFER_REQUEST');
+        if (!peer_connection)
+            createCall(null).then (generateOffer);
+        return;
+    }
+
+    let msg;
+
+    // Handle incoming JSON SDP and ICE messages
+    try {
+        msg = JSON.parse(event.data);
+    } catch (e) {
+        if (e instanceof SyntaxError) {
+            handleIncomingError("Error parsing incoming JSON: " + event.data);
+        } else {
+            handleIncomingError("Unknown error parsing response: " + event.data);
+        }
+        return;
+    }
+
+    // Incoming JSON signals the beginning of a call
+    if (!peer_connection)
+        createCall(msg);
+
+    if (msg.sdp != null) {
+        onIncomingSDP(msg.sdp);
+    } else if (msg.ice != null) {
+        onIncomingICE(msg.ice);
+    } else {
+        handleIncomingError("Unknown incoming JSON: " + msg);
     }
 }
 
@@ -172,26 +171,6 @@ function onServerError(event) {
     window.setTimeout(websocketServerConnect, 3000);
 }
 
-function getLocalStream() {
-    var constraints;
-    var textarea = document.getElementById('constraints');
-    try {
-        constraints = JSON.parse(textarea.value);
-    } catch (e) {
-        console.error(e);
-        setError('ERROR parsing constraints: ' + e.message + ', using default constraints');
-        constraints = default_constraints;
-    }
-    console.log(JSON.stringify(constraints));
-
-    // Add local stream
-    if (navigator.mediaDevices.getUserMedia) {
-        return navigator.mediaDevices.getUserMedia(constraints);
-    } else {
-        errorUserMediaHandler();
-    }
-}
-
 function websocketServerConnect() {
     connect_attempts++;
     if (connect_attempts > 3) {
@@ -202,10 +181,7 @@ function websocketServerConnect() {
     var span = document.getElementById("status");
     span.classList.remove('error');
     span.textContent = '';
-    // Populate constraints
-    var textarea = document.getElementById('constraints');
-    if (textarea.value == '')
-        textarea.value = JSON.stringify(default_constraints);
+
     // Fetch the peer id to use
     peer_id = default_peer_id || getOurId();
     ws_port = ws_port || '8443';
@@ -235,10 +211,6 @@ function onRemoteTrack(event) {
         console.log('Incoming stream');
         getVideoElement().srcObject = event.streams[0];
     }
-}
-
-function errorUserMediaHandler() {
-    setError("Browser doesn't support getUserMedia!");
 }
 
 const handleDataChannelOpen = (event) =>{
@@ -290,29 +262,19 @@ function createCall(msg) {
     send_channel.onclose = handleDataChannelClose;
     peer_connection.ondatachannel = onDataChannel;
     peer_connection.ontrack = onRemoteTrack;
-    /* Send our video/audio to the other peer */
-    local_stream_promise = getLocalStream().then((stream) => {
-        console.log('Adding local stream');
-        peer_connection.addStream(stream);
-        return stream;
-    }).catch(setError);
 
     if (msg != null && !msg.sdp) {
         console.log("WARNING: First message wasn't an SDP message!?");
     }
 
     peer_connection.onicecandidate = (event) => {
-	// We have a candidate, send it to the remote party with the
-	// same uuid
-	if (event.candidate == null) {
-            console.log("ICE Candidate was null, done");
-            return;
-	}
-	ws_conn.send(JSON.stringify({'ice': event.candidate}));
+        // We have a candidate, send it to the remote party with the same uuid
+        if (!event.candidate) {
+            return console.log("ICE Candidate was null, done");
+        }
+
+        ws_conn.send(JSON.stringify({'ice': event.candidate}));
     };
 
-    if (msg != null)
-        setStatus("Created peer connection for call, waiting for SDP");
-
-    return local_stream_promise;
+    if (msg != null) setStatus("Created peer connection for call, waiting for SDP");
 }

--- a/webrtc/signalling/simple_server.py
+++ b/webrtc/signalling/simple_server.py
@@ -227,12 +227,14 @@ class WebRTCSimpleServer(object):
         return uid
 
     def get_ssl_certs(self):
-        if 'letsencrypt' in self.cert_path:
-            chain_pem = os.path.join(self.cert_path, 'fullchain.pem')
-            key_pem = os.path.join(self.cert_path, 'privkey.pem')
-        else:
-            chain_pem = os.path.join(self.cert_path, 'cert.pem')
-            key_pem = os.path.join(self.cert_path, 'key.pem')
+        # if 'letsencrypt' in self.cert_path:
+        #     chain_pem = os.path.join(self.cert_path, 'fullchain.pem')
+        #     key_pem = os.path.join(self.cert_path, 'privkey.pem')
+        # else:
+        #     chain_pem = os.path.join(self.cert_path, 'cert.pem')
+        #     key_pem = os.path.join(self.cert_path, 'key.pem')
+        chain_pem = '/etc/editshare/ssl/server-cert.pem'
+        key_pem = '/etc/editshare/ssl/server.key'
         return chain_pem, key_pem
 
     def get_ssl_ctx(self):


### PR DESCRIPTION
I forked this repo https://github.com/GStreamer/gst-examples for testing WebRTC stuff and added some updates:

 1.  webrtc/sendrecv/gst/webrtc-sendrecv.c

Updated to use /dev/video0 webcam instead of a test input.

2.  webrtc/sendrecv/gst/webrtc_sendrecv.py 

Likewise updated to use video0 webacm and added more test inputs that should be bundled into multiple tracks within one WebRTC stream.

Also fixed one runtime error with getters
```
- offer = reply['offer']
+ offer = reply.get_value('offer')
```

3. In Static html files 

 webrtc/sendrecv/js/index.html and webrtc/sendrecv/js/webrtc.js

I updated these to remove the need for browser to stream audio/video to the server as we're not going to use that.
Also made it dynamic so that when server streams multiple tracks - multiple video elements would appear in a row to simulate upcoming updates in Flow Control.


4. webrtc/signalling/simple_server.py

I think I had a problem with the certs generated by this script: https://github.com/GStreamer/gst-examples/blob/master/webrtc/signalling/generate_cert.sh
So I updated the signaling server to use certs generated by ourselves.
